### PR TITLE
Fix: add temporary OpenAPI spec 

### DIFF
--- a/.gitbook/assets/openapi.yaml
+++ b/.gitbook/assets/openapi.yaml
@@ -2,42 +2,57 @@ openapi: 3.0.0
 paths:
   /v1/allswaps:
     get:
+      description: >-
+        Returns all existing swap pairs with their current volumes and prices in
+        USD.
       operationId: PoolController_getAllSwaps_v1
       parameters: []
       responses:
         "200":
-          description: Successfully returning all existing swaps
+          description: Successfully returning all existing swaps.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AllSwapsResponse"
         "403":
           description: Forbidden
         "404":
           description: Not found
-      summary: Returns all existing swaps with status
+      summary: Returns all available swap pairs
       tags: &ref_0
         - pool
   /v1/pool_stats/{pool_token_id}:
     get:
+      description: >-
+        Returns detailed statistics for a specific swap pool including volumes,
+        fees, liquidity metrics and APR. Data is provided as a time series, with
+        each entry corresponding to a specific Stacks block height.
       operationId: PoolController_getPriceHistory_v1
       parameters:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
-          description: Successfully returning pool stats
+          description: Successfully returning pool stats.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PoolStatsResponse"
         "403":
           description: Forbidden
         "404":
@@ -46,33 +61,41 @@ paths:
       tags: *ref_0
   /v1/pool_volume/{pool_token_id}:
     get:
+      description: >-
+        Returns 24-hour pool volume history for a specific swap pool. Data is
+        provided as a time series, with each entry corresponding to a specific
+        Stacks block height.
       operationId: PoolController_getPoolVolumeHistory_v1
       parameters:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
-          description: Successfully returning volumes
+          description: Successfully returning volumes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PoolVolumeResponse"
         "403":
           description: Forbidden
         "404":
           description: Not found
-      summary: Returns all 24 hour pool volumes in time series
+      summary: Returns daily pool volume
       tags: *ref_0
   /v1/volume_24h/{pool_token_id}:
     get:
@@ -81,19 +104,19 @@ paths:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
@@ -106,63 +129,79 @@ paths:
       tags: *ref_0
   /v1/volume_7d/{pool_token_id}:
     get:
+      description: >-
+        Returns 7-day pool volume history for a specific swap pool. Data is
+        provided as a time series, with each entry corresponding to a specific
+        Stacks block height.
       operationId: PoolController_getVolume7DHistory_v1
       parameters:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
-          description: Successfully returning volumes
+          description: Successfully returning volumes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PoolVolume7DayResponse"
         "403":
           description: Forbidden
         "404":
           description: Not found
-      summary: Returns weekly volumes of token in time series
+      summary: Returns weekly pool volume
       tags: *ref_0
   /v1/pool_liquidity/{pool_token_id}:
     get:
+      description: >-
+        Returns liquidity history for a specific swap pool. Data is provided as
+        a time series, with each entry corresponding to a specific Stacks block
+        height.
       operationId: PoolController_getPoolLiquidityHistory_v1
       parameters:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
-          description: Successfully returning liquidity
+          description: Successfully returning liquidity.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenLiquidityResponse"
         "403":
           description: Forbidden
         "404":
           description: Not found
-      summary: Returns liquidity in time series
+      summary: Returns pool liquidity
       tags: *ref_0
   /v1/liquidity/{pool_token_id}:
     get:
@@ -171,23 +210,27 @@ paths:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
-          required: false
+          required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
           description: Successfully returning liquidity
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenLiquidityResponse"
         "403":
           description: Forbidden
         "404":
@@ -196,33 +239,41 @@ paths:
       tags: *ref_0
   /v1/fee/{pool_token_id}:
     get:
+      description: >-
+        Returns pool's fee rebate history for a specific swap pool. Data is
+        provided as a time series, with each entry corresponding to a specific
+        Stacks block height.
       operationId: PoolController_getFeeHistory_v1
       parameters:
         - name: pool_token_id
           required: true
           in: path
-          description: pool token id of swap pool eg. 13
+          description: Pool token ID of swap pool.
           schema:
             oneOf:
               - type: integer
         - name: offset
           required: false
           in: query
-          description: Specifies the offset of data to be returned, default value is 0
+          description: Specifies the offset of data to be returned, default value is 0.
           schema: {}
         - name: limit
           required: true
           in: query
-          description: Specifies number of data to be returned, default value is 10
+          description: Specifies number of data to be returned, default value is 10.
           schema: {}
       responses:
         "200":
           description: Successfully returning fee
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PoolFeeResponse"
         "403":
           description: Forbidden
         "404":
           description: Not found
-      summary: Returns pool fee in time series
+      summary: Returns pool fee
       tags: *ref_0
   /v1/stats/tvl:
     get:
@@ -1021,6 +1072,325 @@ components:
       bearerFormat: JWT
       type: http
   schemas:
+    Swap:
+      type: object
+      properties:
+        id:
+          type: number
+          example: 7
+        base:
+          type: string
+          example: token-alex
+        baseSymbol:
+          type: string
+          example: alex
+        baseId:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+        quote:
+          type: string
+          example: token-wban
+        quoteSymbol:
+          type: string
+          example: BANANA
+        quoteId:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-wban
+        baseVolume:
+          type: number
+          example: 105.45894916044628
+        quoteVolume:
+          type: number
+          example: 98.15140304673803
+        lastBasePriceInUSD:
+          type: number
+          example: 0.03150216
+        lastQuotePriceInUSD:
+          type: number
+          example: 0.005409090542472804
+      required:
+        - id
+        - base
+        - baseSymbol
+        - baseId
+        - quote
+        - quoteSymbol
+        - quoteId
+        - baseVolume
+        - quoteVolume
+        - lastBasePriceInUSD
+        - lastQuotePriceInUSD
+    AllSwapsResponse:
+      type: object
+      properties:
+        data:
+          description: >-
+            List of all existing swap pairs (base and quote tokens) with their
+            current volumes and prices in USD.
+          type: array
+          items:
+            $ref: "#/components/schemas/Swap"
+      required:
+        - data
+    PoolStatus:
+      type: object
+      properties:
+        pool_token:
+          type: number
+          example: 13
+          description: Unique identifier of the pool token
+        block_height:
+          type: number
+          example: 746617
+          description: Stacks block height at which this status was recorded
+        token_x:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-wstx-v2
+          description: Contract identifier for token X in the pool
+        token_y:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+          description: Contract identifier for token Y in the pool
+        volume_x_24h:
+          type: number
+          example: 112443.97784314597
+          description: 24-hour trading volume for token X
+        volume_y_24h:
+          type: number
+          example: 111321.83151559353
+          description: 24-hour trading volume for token Y
+        volume_24h:
+          type: number
+          example: 225221.63555752003
+          description: Total 24-hour trading volume
+        volume_x_7d:
+          type: number
+          example: 772478.6819111536
+          description: 7-day trading volume for token X
+        volume_y_7d:
+          type: number
+          example: 763925.8164915497
+          description: 7-day trading volume for token Y
+        volume_7d:
+          type: number
+          example: 1548772.3056866901
+          description: Total 7-day trading volume
+        fee_rebate_x_24h:
+          type: number
+          example: 83.41996769813575
+          description: 24-hour fee rebate for token X
+        fee_rebate_y_24h:
+          type: number
+          example: 196.64898177152597
+          description: 24-hour fee rebate for token Y
+        fee_rebate_24h:
+          type: number
+          example: 276.89283447830627
+          description: Total 24-hour fee rebate
+        fee_rebate_x_7d:
+          type: number
+          example: 953.7354657850966
+          description: 7-day fee rebate for token X
+        fee_rebate_y_7d:
+          type: number
+          example: 19723.707926126946
+          description: 7-day fee rebate for token Y
+        fee_rebate_7d:
+          type: number
+          example: 1909.7699233141293
+          description: Total 7-day fee rebate
+        est_pool_token_price:
+          type: number
+          example: 1.8974830418148833e-7
+          description: Estimated price of the pool token
+        liquidity:
+          type: number
+          example: 4092767.3621235755
+          description: Current liquidity in the pool
+        total_supply:
+          type: number
+          example: 4092767.3621156355
+          description: Total supply of pool tokens
+        apr_7d:
+          type: number
+          example: 2.433093588672123
+          description: 7-day Annual Percentage Rate (APR)
+        burn_block_time:
+          type: number
+          example: 1741601675
+          description: Bitcoin's block height
+        sync_at:
+          type: string
+          example: "2025-03-10T10:33:32.378+00:00"
+          description: Timestamp when this data was synchronized
+      required:
+        - pool_token
+        - block_height
+        - token_x
+        - token_y
+        - volume_x_24h
+        - volume_y_24h
+        - volume_24h
+        - volume_x_7d
+        - volume_y_7d
+        - volume_7d
+        - fee_rebate_x_24h
+        - fee_rebate_y_24h
+        - fee_rebate_24h
+        - fee_rebate_x_7d
+        - fee_rebate_y_7d
+        - fee_rebate_7d
+        - est_pool_token_price
+        - liquidity
+        - total_supply
+        - apr_7d
+        - burn_block_time
+        - sync_at
+    PoolStatsResponse:
+      type: object
+      properties:
+        token:
+          type: number
+          example: 13
+          description: Pool token identifier
+        pool_status:
+          description: >-
+            Array of pool status records ordered by block height. All monetary
+            values use base token (token X) units unless explicitly specified
+            with a "_y" suffix for quote token.
+          type: array
+          items:
+            $ref: "#/components/schemas/PoolStatus"
+      required:
+        - token
+        - pool_status
+    VolumeValue:
+      type: object
+      properties:
+        block_height:
+          type: number
+          example: 748628
+          description: Stacks block height at which this status was recorded
+        volume_24h:
+          type: number
+          example: 294318.0656719518
+          description: 24-hour volume in base token (token X) units
+      required:
+        - block_height
+        - volume_24h
+    PoolVolumeResponse:
+      type: object
+      properties:
+        token:
+          type: number
+          example: 13
+          description: Pool token identifier
+        volume_values:
+          description: >-
+            Array of 24-hour pool volume records ordered by block height. All
+            monetary values use base token (token X) units
+          type: array
+          items:
+            $ref: "#/components/schemas/VolumeValue"
+      required:
+        - token
+        - volume_values
+    VolumeValue7Day:
+      type: object
+      properties:
+        block_height:
+          type: number
+          example: 748811
+          description: Stacks block height at which this status was recorded
+        volume_7d:
+          type: number
+          example: 1517660.0316130652
+          description: 7-day volume in base token (token X) units
+      required:
+        - block_height
+        - volume_7d
+    PoolVolume7DayResponse:
+      type: object
+      properties:
+        token:
+          type: number
+          example: 13
+          description: Pool token identifier
+        volume_values:
+          description: >-
+            Array of pool volume records ordered by block height. All monetary
+            values use base token (token X) units
+          type: array
+          items:
+            $ref: "#/components/schemas/VolumeValue7Day"
+      required:
+        - token
+        - volume_values
+    TokenLiquidityValue:
+      type: object
+      properties:
+        block_height:
+          type: number
+          example: 748855
+          description: Stacks block height at which this status was recorded
+        liquidity:
+          type: number
+          example: 3769712.496803321
+          description: Pool liquidity in base token (token X) units
+      required:
+        - block_height
+        - liquidity
+    TokenLiquidityResponse:
+      type: object
+      properties:
+        token:
+          type: number
+          example: 13
+          description: Pool token identifier
+        liquidity_value:
+          description: >-
+            Array of liquidity records ordered by block height. All monetary
+            values use base token (token X) units
+          type: array
+          items:
+            $ref: "#/components/schemas/TokenLiquidityValue"
+      required:
+        - token
+        - liquidity_value
+    PoolFeeValue:
+      type: object
+      properties:
+        block_height:
+          type: number
+          example: 748936
+          description: Stacks block height at which this status was recorded
+        fee_rebate_24h:
+          type: number
+          example: 615.3625117185487
+          description: Fee rebate value for the past 24 hours
+        fee_rebate_7d:
+          type: number
+          example: 3173.3596157582247
+          description: Fee rebate value for the past 7 days
+      required:
+        - block_height
+        - fee_rebate_24h
+        - fee_rebate_7d
+    PoolFeeResponse:
+      type: object
+      properties:
+        pool_token:
+          type: number
+          example: 13
+          description: Pool token identifier
+        fee_value:
+          description: Array of fee rebate records ordered by block height.
+          type: array
+          items:
+            $ref: "#/components/schemas/PoolFeeValue"
+      required:
+        - pool_token
+        - fee_value
     Ticker:
       type: object
       properties:

--- a/.gitbook/assets/openapi.yaml
+++ b/.gitbook/assets/openapi.yaml
@@ -1,0 +1,1175 @@
+openapi: 3.0.0
+paths:
+  /v1/allswaps:
+    get:
+      operationId: PoolController_getAllSwaps_v1
+      parameters: []
+      responses:
+        '200':
+          description: Successfully returning all existing swaps
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns all existing swaps with status
+      tags: &ref_0
+        - pool
+  /v1/pool_stats/{pool_token_id}:
+    get:
+      operationId: PoolController_getPriceHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning pool stats
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns pool stats
+      tags: *ref_0
+  /v1/pool_volume/{pool_token_id}:
+    get:
+      operationId: PoolController_getPoolVolumeHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning volumes
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns all 24 hour pool volumes in time series
+      tags: *ref_0
+  /v1/volume_24h/{pool_token_id}:
+    get:
+      operationId: PoolController_getVolume24HRHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning volumes
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns daily volumes of token in time series
+      tags: *ref_0
+  /v1/volume_7d/{pool_token_id}:
+    get:
+      operationId: PoolController_getVolume7DHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning volumes
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns weekly volumes of token in time series
+      tags: *ref_0
+  /v1/pool_liquidity/{pool_token_id}:
+    get:
+      operationId: PoolController_getPoolLiquidityHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning liquidity
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns liquidity in time series
+      tags: *ref_0
+  /v1/liquidity/{pool_token_id}:
+    get:
+      operationId: PoolController_getLiquidityHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: false
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning liquidity
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns liquidity of token in time series
+      tags: *ref_0
+  /v1/fee/{pool_token_id}:
+    get:
+      operationId: PoolController_getFeeHistory_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: true
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning fee
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns pool fee in time series
+      tags: *ref_0
+  /v1/stats/tvl:
+    get:
+      operationId: StatsController_getTVL_v1
+      parameters: []
+      responses:
+        '200':
+          description: Successfully returning TVL
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns total TVL(total value locked) value of ALEX platform
+      tags: &ref_1
+        - stats
+  /v1/stats/tvl/{token}:
+    get:
+      operationId: StatsController_getTokenTVL_v1
+      parameters:
+        - name: token
+          required: true
+          in: path
+          schema:
+            type: string
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: false
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning liquidity
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns token TVL(total value locked) in time series
+      tags: *ref_1
+  /v1/stats/total_supply/{token}:
+    get:
+      operationId: StatsController_getTotalSupply_v1
+      parameters:
+        - name: token
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successfully returning total supply
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns total supply of queried token eg. age000-governance-token
+      tags: *ref_1
+  /v1/stats/circulating_supply/age000-governance-token:
+    get:
+      operationId: StatsController_getCirculatingSupply_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_1
+  /v1/price/{token}:
+    get:
+      operationId: PriceController_getPrice_v1
+      parameters:
+        - name: token
+          required: true
+          in: path
+          description: >-
+            name of token eg.
+            SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+      responses:
+        '200':
+          description: Successfully returning price
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns price of token
+      tags: &ref_2
+        - price
+  /v1/pool_token_price/{pool_token_id}:
+    get:
+      operationId: PriceController_getPoolTokenPrice_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+      responses:
+        '200':
+          description: Successfully returning Pool token price
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns pool token price value of ALEX platform
+      tags: *ref_2
+  /v1/pool_token_stats:
+    get:
+      operationId: PriceController_getAllPoolTokenPrice_v1
+      parameters: []
+      responses:
+        '200':
+          description: Successfully returning all existing pool token stats
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns pool token price value of ALEX platform
+      tags: *ref_2
+  /v1/price_history/{token}:
+    get:
+      operationId: PriceController_getPriceHistory_v1
+      parameters:
+        - name: token
+          required: true
+          in: path
+          description: >-
+            name of token eg.
+            SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+        - name: order_by
+          required: false
+          in: query
+          description: >-
+            Specifies the order of block height to be returned, default value is
+            desc
+          schema: {}
+        - name: end_block_height
+          required: false
+          in: query
+          description: Specifies the end block height of data to be returned
+          schema: {}
+        - name: start_block_height
+          required: false
+          in: query
+          description: Specifies the start block height of data to be returned
+          schema: {}
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: false
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning price history
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns price history of token
+      tags: *ref_2
+  /v1/price_history_15min/{token}:
+    get:
+      operationId: PriceController_getPriceHistory15Min_v1
+      parameters:
+        - name: token
+          required: true
+          in: path
+          description: >-
+            name of token eg.
+            SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+        - name: order_by
+          required: false
+          in: query
+          description: >-
+            Specifies the order of block height to be returned, default value is
+            desc
+          schema: {}
+        - name: end_ts
+          required: true
+          in: query
+          description: Specifies the end unix timestamp of data to be returned
+          schema: {}
+        - name: start_ts
+          required: true
+          in: query
+          description: Specifies the start unix timestamp of data to be returned
+          schema: {}
+        - name: offset
+          required: false
+          in: query
+          description: Specifies the offset of data to be returned, default value is 0
+          schema: {}
+        - name: limit
+          required: false
+          in: query
+          description: Specifies number of data to be returned, default value is 10
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning price history 15min
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns price history 15min of token
+      tags: *ref_2
+  /v1/pairs:
+    get:
+      operationId: DexController_getAllPairs_v1
+      parameters: []
+      responses:
+        '200':
+          description: Successfully returning all existing pairs
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns all existing pairs
+      tags: &ref_3
+        - dex
+  /v1/tickers:
+    get:
+      operationId: DexController_getAllTickers_v1
+      parameters: []
+      responses:
+        '200':
+          description: Successfully returning all markets statistics for the last 24 hours
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns all markets statistics for the last 24 hours
+      tags: *ref_3
+  /v1/ticker/{ticker_id}:
+    get:
+      operationId: DexController_getTicker_v1
+      parameters:
+        - name: ticker_id
+          required: true
+          in: path
+          description: >-
+            A ticker with delimiter between different cryptoassets eg.
+            SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex_stx
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+      responses:
+        '200':
+          description: Successfully returning all historical trades of certain ticker
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      tags: *ref_3
+  /v1/orderbook/{ticker}:
+    get:
+      operationId: DexController_getOrderBookTicker_v1
+      parameters:
+        - name: ticker
+          required: true
+          in: path
+          description: A ticker with delimiter between different cryptoassets eg. ALEX_WSLM
+          schema:
+            oneOf:
+              - type: string
+              - type: integer
+      responses:
+        '200':
+          description: Successfully returning all historical trades of certain ticker
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      tags: *ref_3
+  /v1/historical_swaps/{pool_token_id}:
+    get:
+      operationId: DexController_getHistoricalTrades_v1
+      parameters:
+        - name: pool_token_id
+          required: true
+          in: path
+          description: pool token id of swap pool eg. 13
+          schema:
+            oneOf:
+              - type: integer
+        - name: limit
+          required: true
+          in: query
+          description: >-
+            Specifies number of recent block heights to be returned, default
+            value is 1000
+          schema: {}
+      responses:
+        '200':
+          description: Successfully returning all historical trades of certain ticker
+        '403':
+          description: Forbidden
+        '404':
+          description: Not found
+      summary: Returns all existing historical trades
+      tags: *ref_3
+  /v2/coin-gecko/pairs:
+    get:
+      operationId: CoinGeckoController_getPairsV2_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: &ref_4
+        - coin-gecko
+  /v2/coin-gecko/tickers:
+    get:
+      operationId: CoinGeckoController_getTickersV2_v2
+      parameters: []
+      responses:
+        '200':
+          description: 'Get all tickers from AMM '
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Ticker'
+      tags: *ref_4
+  /v1/brc20/user-balance:
+    get:
+      operationId: Brc20Controller_userBalance_v1
+      parameters:
+        - name: tick
+          required: true
+          in: query
+          schema:
+            example: ORMM
+            type: string
+        - name: user
+          required: true
+          in: query
+          schema:
+            example: bc1phpa7ym29gdwulxv62c20su2nh2039vad04hhawyuwztt54weff2suawxly
+            type: string
+      responses:
+        '200':
+          description: Successfully returning user balance
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserBalanceResponse'
+      tags: &ref_5
+        - brc20
+  /v1/brc20/bitcoin-tx-indexed:
+    get:
+      operationId: Brc20Controller_bitcoinTxIndexed_v1
+      parameters:
+        - name: bitcoin-tx-id
+          required: true
+          in: query
+          schema:
+            example: 498f108b18f5a5b2dec1f31133c7da8260b44711c1bd387728eb51ac146e1d7f
+            type: string
+        - name: offset
+          required: true
+          in: query
+          schema:
+            example: 0
+            type: number
+        - name: output
+          required: true
+          in: query
+          schema:
+            example: 0
+            type: number
+      responses:
+        '200':
+          description: Successfully returning bitcoin tx indexed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BitcoinTxIndexedResponse'
+      tags: *ref_5
+  /v2/stx-tools/pools:
+    get:
+      operationId: StxToolsController_getPools_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: &ref_6
+        - StxTools
+  /v2/stx-tools/token-prices:
+    get:
+      operationId: StxToolsController_getTokenPrices_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_6
+  /v2/stx-tools:
+    get:
+      operationId: StxToolsController_getAll_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_6
+  /v1/galxe/check-bridged:
+    get:
+      operationId: GalxeController_checkBridged_v1
+      parameters:
+        - name: address
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: chain_id
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: start
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: end
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags:
+        - Galxe
+  /v1/public/token-prices:
+    get:
+      operationId: PublicController_getTokenPrices_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: &ref_7
+        - Public
+  /v2/public/token-prices:
+    get:
+      operationId: PublicController_getTokenPricesV2_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/history-prices:
+    get:
+      operationId: PublicController_getHistoryPrices_v1
+      parameters:
+        - name: limit
+          required: true
+          in: query
+          schema:
+            type: number
+        - name: offset
+          required: true
+          in: query
+          schema:
+            type: number
+        - name: block_heights
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: token
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: wrapped_token
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: burn_block_time
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: sort
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: sort_by
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/synced-blocks:
+    get:
+      operationId: PublicController_getSyncedBlock_v1
+      parameters:
+        - name: limit
+          required: true
+          in: query
+          schema:
+            type: number
+        - name: offset
+          required: true
+          in: query
+          schema:
+            type: number
+        - name: block_heights
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: burn_block_time
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: sort
+          required: true
+          in: query
+          schema:
+            type: string
+        - name: sort_by
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/token-mappings:
+    get:
+      operationId: PublicController_getTokenMapping_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/token-mappings:
+    get:
+      operationId: PublicController_getTokenMappingV2_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/pools:
+    get:
+      operationId: PublicController_getPools_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/pools:
+    get:
+      operationId: PublicController_getPoolsV2_v2
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/pairs:
+    get:
+      operationId: PublicController_getPairs_v1
+      parameters: []
+      responses:
+        '200':
+          description: 'Get all token pairs from AMM '
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenPairResponse'
+      tags: *ref_7
+  /v1/public/amm-pool-stats:
+    get:
+      operationId: PublicController_getAmmPoolStats_v1
+      parameters: []
+      responses:
+        '200':
+          description: Get all stats of AMM pools
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AmmPoolStatsResponse'
+      tags: *ref_7
+  /v1/public/hackers:
+    get:
+      operationId: PublicController_getHackers_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/addresses/{address}/auto-alex-v3-rewards:
+    get:
+      operationId: PublicController_getAutoAlexV3RewardsByAddress_v1
+      parameters:
+        - name: address
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/auto-alex-v3/rewards:
+    get:
+      operationId: PublicController_getAutoAlexV3RewardsByCycle_v1
+      parameters:
+        - name: cycle
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/lqstx/rewards:
+    get:
+      operationId: PublicController_getLqstxRewardsByCycle_v1
+      parameters:
+        - name: cycle
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/addresses/{address}/lqstx-rewards:
+    get:
+      operationId: PublicController_getLqstxRewardsByAddress_v1
+      parameters:
+        - name: address
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/addresses/{address}/auto-alex-v3-rewards:
+    get:
+      operationId: PublicController_getAutoAlexV3RewardsByAddressV2_v2
+      parameters:
+        - name: address
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/auto-alex-v3/rewards:
+    get:
+      operationId: PublicController_getAutoAlexV3RewardsByCycleV2_v2
+      parameters:
+        - name: cycle
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/lqstx/rewards:
+    get:
+      operationId: PublicController_getLqstxRewardsByCycleV2_v2
+      parameters:
+        - name: cycle
+          required: true
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v2/public/addresses/{address}/lqstx-rewards:
+    get:
+      operationId: PublicController_getLqstxRewardsByAddressV2_v2
+      parameters:
+        - name: address
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/treasury-grant-records:
+    get:
+      operationId: PublicController_getTreasuryGrantRecords_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/public/surge-vote-analysis/{id}:
+    get:
+      operationId: PublicController_surge_v1
+      parameters:
+        - name: id
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_7
+  /v1/_internal/hackers:
+    get:
+      operationId: InternalController_getHackers_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags: &ref_8
+        - Internal
+  /v1/_internal/addresses/{address}/flow-transactions:
+    get:
+      operationId: InternalController_getFlowTransactionsByAddress_v1
+      parameters:
+        - name: address
+          required: true
+          in: path
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+      tags: *ref_8
+  /v1/malicious:
+    get:
+      operationId: MaliciousController_getHackers_v1
+      parameters: []
+      responses:
+        '200':
+          description: ''
+      tags:
+        - Malicious
+info:
+  title: ALEX REST API
+  description: ALEX Open API service
+  version: '1.0'
+  contact:
+    name: ALEX Development Team
+    url: https://www.alexgo.io
+    email: talkto@alexgo.io
+tags:
+  - name: ALEX REST API
+    description: ALEX Open API for public usage
+servers:
+  - url: https://api.alexgo.io
+    description: Production environment
+components:
+  securitySchemes:
+    bearer:
+      scheme: bearer
+      bearerFormat: JWT
+      type: http
+  schemas:
+    Ticker:
+      type: object
+      properties:
+        ticker_id:
+          type: string
+          description: ticker id with delimiter between different cryptoassets.
+          example: SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-slunr_stx
+        pool_id:
+          type: string
+          description: pool id with delimiter between different cryptoassets.
+          example: SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-amm-swap-pool-v1-1
+        base_currency:
+          type: string
+          example: SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-slunr
+        target_currency:
+          type: string
+          example: stx
+        base:
+          type: string
+          description: display name of base currency.
+          example: sLUNR
+        target:
+          type: string
+          description: display name of target currency.
+          example: STX
+        last_price:
+          type: number
+          example: 0.08540716070881907
+        base_volume:
+          type: number
+          example: 0.08540716070881907
+        target_volume:
+          type: number
+          example: 22589.502469
+        liquidity_in_usd:
+          type: number
+          example: 22062.86716874599
+      required:
+        - ticker_id
+        - pool_id
+        - base_currency
+        - target_currency
+        - base
+        - target
+        - last_price
+        - base_volume
+        - target_volume
+        - liquidity_in_usd
+    UserBalanceResponse:
+      type: object
+      properties:
+        balance:
+          type: string
+          description: user balance of given asset
+          example: '1000000000000000'
+        up-to-block:
+          type: string
+          description: latest block height
+          example: '811363'
+      required:
+        - balance
+        - up-to-block
+    BitcoinTxIndexedResponse:
+      type: object
+      properties:
+        from:
+          type: string
+          description: from address
+          example: 0xbc1pngxflzuqe5vevtc8fgmxzl69pw74x36dc9pmv5rye6nhwty0c0hsh5tyr3
+        to:
+          type: string
+          description: to address
+          example: 0xbc1p06r44ervnukj3kxnqt863sz9hly5m7f80k7l94aplnd6z2tnrzvstdkzsq
+        amt:
+          type: string
+          description: amount of assets
+          example: '10000000000000000000000000000'
+        tick:
+          type: string
+          description: asset id
+          example: sats
+      required:
+        - from
+        - to
+        - amt
+        - tick
+    AmmTokenPair:
+      type: object
+      properties:
+        pool_id:
+          type: number
+          example: 13
+        token_x:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-wxusd
+        wrapped_token_x:
+          type: string
+          example: SP2TZK01NKDC89J6TA56SA47SDF7RTHYEQ79AAB9A.Wrapped-USD
+        token_y:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-wusda
+        wrapped_token_y:
+          type: string
+          example: SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token
+      required:
+        - pool_id
+        - token_x
+        - wrapped_token_x
+        - token_y
+        - wrapped_token_y
+    TokenPairResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AmmTokenPair'
+      required:
+        - data
+    AmmPoolStats:
+      type: object
+      properties:
+        pool_id:
+          type: number
+          example: 13
+        target_token:
+          type: string
+          example: STX
+        base_token:
+          type: string
+          example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
+        tvl:
+          type: string
+          example: '4800976.56479834'
+        apy:
+          type: string
+          example: '0.017392667325066296'
+      required:
+        - pool_id
+        - target_token
+        - base_token
+        - tvl
+        - apy
+    AmmPoolStatsResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AmmPoolStats'
+      required:
+        - data

--- a/.gitbook/assets/openapi.yaml
+++ b/.gitbook/assets/openapi.yaml
@@ -5,11 +5,11 @@ paths:
       operationId: PoolController_getAllSwaps_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Successfully returning all existing swaps
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns all existing swaps with status
       tags: &ref_0
@@ -36,11 +36,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning pool stats
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns pool stats
       tags: *ref_0
@@ -66,11 +66,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning volumes
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns all 24 hour pool volumes in time series
       tags: *ref_0
@@ -96,11 +96,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning volumes
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns daily volumes of token in time series
       tags: *ref_0
@@ -126,11 +126,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning volumes
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns weekly volumes of token in time series
       tags: *ref_0
@@ -156,11 +156,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning liquidity
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns liquidity in time series
       tags: *ref_0
@@ -186,11 +186,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning liquidity
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns liquidity of token in time series
       tags: *ref_0
@@ -216,11 +216,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning fee
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns pool fee in time series
       tags: *ref_0
@@ -229,11 +229,11 @@ paths:
       operationId: StatsController_getTVL_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Successfully returning TVL
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns total TVL(total value locked) value of ALEX platform
       tags: &ref_1
@@ -258,11 +258,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning liquidity
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns token TVL(total value locked) in time series
       tags: *ref_1
@@ -276,11 +276,11 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Successfully returning total supply
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns total supply of queried token eg. age000-governance-token
       tags: *ref_1
@@ -289,8 +289,8 @@ paths:
       operationId: StatsController_getCirculatingSupply_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_1
   /v1/price/{token}:
     get:
@@ -307,11 +307,11 @@ paths:
               - type: string
               - type: integer
       responses:
-        '200':
+        "200":
           description: Successfully returning price
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns price of token
       tags: &ref_2
@@ -328,11 +328,11 @@ paths:
             oneOf:
               - type: integer
       responses:
-        '200':
+        "200":
           description: Successfully returning Pool token price
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns pool token price value of ALEX platform
       tags: *ref_2
@@ -341,11 +341,11 @@ paths:
       operationId: PriceController_getAllPoolTokenPrice_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Successfully returning all existing pool token stats
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns pool token price value of ALEX platform
       tags: *ref_2
@@ -391,11 +391,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning price history
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns price history of token
       tags: *ref_2
@@ -441,11 +441,11 @@ paths:
           description: Specifies number of data to be returned, default value is 10
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning price history 15min
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns price history 15min of token
       tags: *ref_2
@@ -454,11 +454,11 @@ paths:
       operationId: DexController_getAllPairs_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Successfully returning all existing pairs
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns all existing pairs
       tags: &ref_3
@@ -468,11 +468,11 @@ paths:
       operationId: DexController_getAllTickers_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Successfully returning all markets statistics for the last 24 hours
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns all markets statistics for the last 24 hours
       tags: *ref_3
@@ -491,11 +491,11 @@ paths:
               - type: string
               - type: integer
       responses:
-        '200':
+        "200":
           description: Successfully returning all historical trades of certain ticker
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       tags: *ref_3
   /v1/orderbook/{ticker}:
@@ -511,11 +511,11 @@ paths:
               - type: string
               - type: integer
       responses:
-        '200':
+        "200":
           description: Successfully returning all historical trades of certain ticker
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       tags: *ref_3
   /v1/historical_swaps/{pool_token_id}:
@@ -537,11 +537,11 @@ paths:
             value is 1000
           schema: {}
       responses:
-        '200':
+        "200":
           description: Successfully returning all historical trades of certain ticker
-        '403':
+        "403":
           description: Forbidden
-        '404':
+        "404":
           description: Not found
       summary: Returns all existing historical trades
       tags: *ref_3
@@ -550,8 +550,8 @@ paths:
       operationId: CoinGeckoController_getPairsV2_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: &ref_4
         - coin-gecko
   /v2/coin-gecko/tickers:
@@ -559,14 +559,14 @@ paths:
       operationId: CoinGeckoController_getTickersV2_v2
       parameters: []
       responses:
-        '200':
-          description: 'Get all tickers from AMM '
+        "200":
+          description: "Get all tickers from AMM "
           content:
             application/json:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Ticker'
+                  $ref: "#/components/schemas/Ticker"
       tags: *ref_4
   /v1/brc20/user-balance:
     get:
@@ -585,12 +585,12 @@ paths:
             example: bc1phpa7ym29gdwulxv62c20su2nh2039vad04hhawyuwztt54weff2suawxly
             type: string
       responses:
-        '200':
+        "200":
           description: Successfully returning user balance
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserBalanceResponse'
+                $ref: "#/components/schemas/UserBalanceResponse"
       tags: &ref_5
         - brc20
   /v1/brc20/bitcoin-tx-indexed:
@@ -616,20 +616,20 @@ paths:
             example: 0
             type: number
       responses:
-        '200':
+        "200":
           description: Successfully returning bitcoin tx indexed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BitcoinTxIndexedResponse'
+                $ref: "#/components/schemas/BitcoinTxIndexedResponse"
       tags: *ref_5
   /v2/stx-tools/pools:
     get:
       operationId: StxToolsController_getPools_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: &ref_6
         - StxTools
   /v2/stx-tools/token-prices:
@@ -637,16 +637,16 @@ paths:
       operationId: StxToolsController_getTokenPrices_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_6
   /v2/stx-tools:
     get:
       operationId: StxToolsController_getAll_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_6
   /v1/galxe/check-bridged:
     get:
@@ -673,8 +673,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags:
         - Galxe
   /v1/public/token-prices:
@@ -682,8 +682,8 @@ paths:
       operationId: PublicController_getTokenPrices_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: &ref_7
         - Public
   /v2/public/token-prices:
@@ -691,8 +691,8 @@ paths:
       operationId: PublicController_getTokenPricesV2_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/history-prices:
     get:
@@ -739,8 +739,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/synced-blocks:
     get:
@@ -777,72 +777,72 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/token-mappings:
     get:
       operationId: PublicController_getTokenMapping_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/token-mappings:
     get:
       operationId: PublicController_getTokenMappingV2_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/pools:
     get:
       operationId: PublicController_getPools_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/pools:
     get:
       operationId: PublicController_getPoolsV2_v2
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/pairs:
     get:
       operationId: PublicController_getPairs_v1
       parameters: []
       responses:
-        '200':
-          description: 'Get all token pairs from AMM '
+        "200":
+          description: "Get all token pairs from AMM "
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TokenPairResponse'
+                $ref: "#/components/schemas/TokenPairResponse"
       tags: *ref_7
   /v1/public/amm-pool-stats:
     get:
       operationId: PublicController_getAmmPoolStats_v1
       parameters: []
       responses:
-        '200':
+        "200":
           description: Get all stats of AMM pools
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AmmPoolStatsResponse'
+                $ref: "#/components/schemas/AmmPoolStatsResponse"
       tags: *ref_7
   /v1/public/hackers:
     get:
       operationId: PublicController_getHackers_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/addresses/{address}/auto-alex-v3-rewards:
     get:
@@ -854,8 +854,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/auto-alex-v3/rewards:
     get:
@@ -867,8 +867,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/lqstx/rewards:
     get:
@@ -880,8 +880,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/addresses/{address}/lqstx-rewards:
     get:
@@ -893,8 +893,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/addresses/{address}/auto-alex-v3-rewards:
     get:
@@ -906,8 +906,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/auto-alex-v3/rewards:
     get:
@@ -919,8 +919,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/lqstx/rewards:
     get:
@@ -932,8 +932,8 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v2/public/addresses/{address}/lqstx-rewards:
     get:
@@ -945,16 +945,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/treasury-grant-records:
     get:
       operationId: PublicController_getTreasuryGrantRecords_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/public/surge-vote-analysis/{id}:
     get:
@@ -966,16 +966,16 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_7
   /v1/_internal/hackers:
     get:
       operationId: InternalController_getHackers_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: &ref_8
         - Internal
   /v1/_internal/addresses/{address}/flow-transactions:
@@ -988,22 +988,22 @@ paths:
           schema:
             type: string
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags: *ref_8
   /v1/malicious:
     get:
       operationId: MaliciousController_getHackers_v1
       parameters: []
       responses:
-        '200':
-          description: ''
+        "200":
+          description: ""
       tags:
         - Malicious
 info:
   title: ALEX REST API
   description: ALEX Open API service
-  version: '1.0'
+  version: "1.0"
   contact:
     name: ALEX Development Team
     url: https://www.alexgo.io
@@ -1075,11 +1075,11 @@ components:
         balance:
           type: string
           description: user balance of given asset
-          example: '1000000000000000'
+          example: "1000000000000000"
         up-to-block:
           type: string
           description: latest block height
-          example: '811363'
+          example: "811363"
       required:
         - balance
         - up-to-block
@@ -1097,7 +1097,7 @@ components:
         amt:
           type: string
           description: amount of assets
-          example: '10000000000000000000000000000'
+          example: "10000000000000000000000000000"
         tick:
           type: string
           description: asset id
@@ -1137,7 +1137,7 @@ components:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/AmmTokenPair'
+            $ref: "#/components/schemas/AmmTokenPair"
       required:
         - data
     AmmPoolStats:
@@ -1154,10 +1154,10 @@ components:
           example: SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.token-alex
         tvl:
           type: string
-          example: '4800976.56479834'
+          example: "4800976.56479834"
         apy:
           type: string
-          example: '0.017392667325066296'
+          example: "0.017392667325066296"
       required:
         - pool_id
         - target_token
@@ -1170,6 +1170,6 @@ components:
         data:
           type: array
           items:
-            $ref: '#/components/schemas/AmmPoolStats'
+            $ref: "#/components/schemas/AmmPoolStats"
       required:
         - data

--- a/developers/api-references.md
+++ b/developers/api-references.md
@@ -2,98 +2,98 @@
 
 Front-end developers may use our REST API ([https://api.alexgo.io](https://api.alexgo.io)) to access the latest market data on ALEX.
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/allswaps" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/allswaps" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pool_stats/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pool_stats/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pool_volume/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pool_volume/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/volume_24h/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/volume_24h/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/volume_7d/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/volume_7d/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pool_liquidity/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pool_liquidity/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/liquidity/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/liquidity/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/fee/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/fee/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/stats/tvl" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/stats/tvl" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/stats/tvl/{token}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/stats/tvl/{token}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/stats/total_supply/{token}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/stats/total_supply/{token}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/price/{token}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/price/{token}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pool_token_price/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pool_token_price/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pool_token_stats" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pool_token_stats" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/price_history/{token}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/price_history/{token}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/pairs" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/pairs" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/tickers" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/tickers" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/ticker/{ticker_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/ticker/{ticker_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/orderbook/{ticker}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/orderbook/{ticker}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/historical_swaps/{pool_token_id}" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/historical_swaps/{pool_token_id}" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v2/coin-gecko/pairs" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v2/coin-gecko/pairs" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v2/coin-gecko/tickers" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v2/coin-gecko/tickers" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/public/pairs" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/public/pairs" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}
 
-{% swagger src="https://api.alexgo.io/swagger-ui-yaml" path="/v1/public/amm-pool-stats" method="get" %}
-[https://api.alexgo.io/swagger-ui-yaml](https://api.alexgo.io/swagger-ui-yaml)
+{% swagger src="../.gitbook/assets/openapi.yaml" path="/v1/public/amm-pool-stats" method="get" %}
+[../.gitbook/assets/openapi.yaml](../.gitbook/assets/openapi.yaml)
 {% endswagger %}


### PR DESCRIPTION
## Description

Impacts on https://docs.alexgo.io/. This branch is live at a temporary URL [here](https://coinfabrik.gitbook.io/alex-v1-docs/developers/api-references).

Added a temporary OpenAPI spec until the production one at https://api.alexgo.io/swagger-ui-yaml is ready. The corresponding PRs on the API repo are:

- https://github.com/alexgo-io/alex-rest-api-v1/pull/3
- https://github.com/alexgo-io/alex-rest-api-v1/pull/4

## Fix

`Test it` button on Gitbook works ✅ 

## Enhance

Added decorators to improve pool endpoints documentation. The following endpoints were updated (all present in `pool.controller.ts` file of the API):

- `/v1/allswaps`
- `/v1/pool_stats/{pool_token_id}`
- `/v1/pool_volume/{pool_token_id}`
- `/v1/volume_7d/{pool_token_id}`
- `/v1/pool_liquidity/{pool_token_id}`
- `/v1/fee/{pool_token_id}`