### PR TITLE
Developers: add permissionless contract documentation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -49,4 +49,5 @@
   * [amm-registry-v2-01.clar](developers/protocol-contracts/amm-registry-v2-01.clar.md)
   * [amm-vault-v2-01.clar](developers/protocol-contracts/amm-vault-v2-01.clar.md)
   * [farming-campaign-v2-02.clar](developers/protocol-contracts/farming-campaign-v2-02.clar.md)
+  * [self-listing-helper-v3a.clar](developers/protocol-contracts/self-listing-helper-v3a.clar.md)
 * [REST API](developers/api-references.md)

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -1,0 +1,155 @@
+# self-listing-helper-v3a.clar
+
+- [Deployed contract](https://explorer.hiro.so/txid/SP1E0XBN9T4B10E9QMR7XMFJPMA19D77WY3KP2QKC.self-listing-helper-v3a?chain=mainnet)
+
+The `self-listing-helper-v3a` contract enables the creation of trading pools on the ALEX DEX through two distinct mechanisms: a permissioned flow and a permissionless flow.
+
+In the **permissioned flow**, pre-approved tokens can create pools by following a guided process through the ALEX UI. These tokens must be whitelisted and have sufficient anchor token liquidity.
+
+In the **permissionless flow**, any user can list a new token by deploying a wrapper contract that matches an approved template. The contract includes a verification system to ensure the integrity of the deployment: it reconstructs and validates the original contract transaction using Merkle proofs and block data, confirming that the wrapper is trustworthy.
+
+Once verification succeeds, the token is dynamically approved and a pool is created.
+
+The contract also supports:
+- Liquidity locking or burning for pool integrity
+- On-chain parameter configuration (fees, oracles, thresholds)
+- Governance-controlled token approvals
+- Rebates management for AMM incentives
+
+This dual approach gives projects the flexibility to choose between a guided listing process or a fully autonomous, on-chain setup — all while using the same core infrastructure.
+
+## Features
+
+### Public Features
+
+#### `create` 
+
+This function initiates the creation of a liquidity pool between two pre-approved tokens. It is used in the **permissioned listing** flow, where the listing token (`token-y`) has already been approved by governance or whitelisted in the system.
+
+The function first runs validation checks via `pre-check`, which ensures the anchor token (`token-x`) is approved and that the caller provides sufficient liquidity. It also checks that no existing pool with the given token pair and `factor` already exists.
+
+Next, it verifies that the listing token has a reserve in the `amm-vault-v2-01` contract, which serves as a proxy for its approval status.
+
+If all validations pass, the function calls `post-check`, which:
+- Creates the new pool on `amm-pool-v2-01`
+- Configures its parameters (fees, thresholds, oracle)
+- Applies LP token lock or burn rules via `liquidity-locker` if requested
+
+The function emits a print log with the full pool configuration for transparency.
+
+##### Parameters
+
+| Name             | Type       |
+|------------------|------------|
+| `request-details`| `{ token-x-trait: <ft-trait>, token-y-trait: <ft-trait>, factor: uint, bal-x: uint, bal-y: uint, fee-rate-x: uint, fee-rate-y: uint, max-in-ratio: uint, max-out-ratio: uint, threshold-x: uint, threshold-y: uint, oracle-enabled: bool, oracle-average: uint, start-block: uint, lock: (buff 1) }` |
+
+#### `create2`
+
+This function allows the creation of a new liquidity pool using a token that has **not been pre-approved** by governance. It is the main entry point for the **permissionless listing** flow.
+
+Before calling this function, the user must deploy a wrapper contract for the listing token (`token-y`) that matches an approved template. The contract must then be verified on-chain by submitting proof of deployment.
+
+The function begins by validating the request with `pre-check`. It then calls `verify-deploy`, which:
+- Reconstructs the transaction ID based on the deployment parameters
+- Validates that the contract was mined using a Merkle proof and block data
+- Ensures the code matches the wrapper template stored in this contract
+
+If verification succeeds, the wrapper is stored in `wrap-token-map`, and `token-y` is dynamically approved via `amm-vault-v2-01.set-approved-token`.
+
+Finally, `post-check` is executed to create the pool and configure its parameters. The function emits a print log with both the request and verification details.
+
+##### Parameters
+
+| Name             | Type       |
+|------------------|------------|
+| `request-details`| `{ token-x-trait: <ft-trait>, token-y-trait: <ft-trait>, factor: uint, bal-x: uint, bal-y: uint, fee-rate-x: uint, fee-rate-y: uint, max-in-ratio: uint, max-out-ratio: uint, threshold-x: uint, threshold-y: uint, oracle-enabled: bool, oracle-average: uint, start-block: uint, lock: (buff 1) }` |
+| `verify-params`  | `{ nonce: (buff 8), fee-rate: (buff 8), signature: (buff 65), contract: principal, token-y: principal, proof: { tx-index: uint, hashes: (list 14 (buff 32)), tree-depth: uint }, tx-block-height: uint, block-header-without-signer-signatures: (buff 712) }` |
+
+#### `lock-liquidity`
+
+This function locks a specified amount of LP tokens for a given pool. It is typically used immediately after a pool is created, when the creator chooses to lock the initial liquidity as a trust signal for other users.
+
+Internally, it calls the `lock-liquidity` function of the external `.liquidity-locker` contract. That contract:
+- Transfers the LP tokens from the caller to its own custody
+- Records the locked amount and sets an unlock block height (default: ~6 months)
+
+##### Parameters
+
+| Name       | Type   |
+|------------|--------|
+| `amount`   | `uint` |
+| `pool-id`  | `uint` |
+
+#### `burn-liquidity`
+
+This function allows the caller to burn a specified amount of LP tokens from a given pool. It is one of the options available when configuring the pool after creation, typically used to make the initial liquidity permanently inaccessible.
+
+Internally, it calls the `burn-liquidity` function of the external `.liquidity-locker` contract. That contract:
+- Calls the `burn-fixed` function on the pool contract to destroy the LP tokens
+- Updates the internal `burnt-liquidity` record for that pool
+
+##### Parameters
+
+| Name       | Type   |
+|------------|--------|
+| `amount`   | `uint` |
+| `pool-id`  | `uint` |
+
+#### `claim-liquidity`
+
+This function allows users to reclaim their previously locked LP tokens after the lock period has expired.
+
+Internally, it calls the `claim-liquidity` function from the external `liquidity-locker` contract. That contract:
+- Checks that the caller has a non-zero locked amount
+- Verifies that the current block is past the `end-burn-block` set during locking
+- Transfers the LP tokens back to the user
+- Deletes the corresponding lock record
+
+##### Parameters
+
+| Name       | Type   |
+|------------|--------|
+| `pool-id`  | `uint` |
+
+### Governance Features
+
+#### `is-dao-or-extension`
+This standard protocol function checks whether a caller (`tx-sender`) is the DAO executor or an authorized extension, delegating the extensions check to the `executor-dao` contract.
+
+#### `approve-token-x`
+
+A public function, governed through the `is-dao-or-extension`, that sets the approval status and minimum required balance for a token to be used as the anchor token (`token-x`) in pool creation.
+
+This function updates the `approved-token-x` map, enabling the protocol to define which tokens can serve as anchors and to enforce a minimum contribution threshold (`min-x`) for those tokens.
+
+##### Parameters
+
+| Name       | Type      |
+|------------|-----------|
+| `token`    | `principal` |
+| `approved` | `bool`      |
+| `min-x`    | `uint`      |
+
+#### `set-fee-rebate`
+
+A public function, governed through the `is-dao-or-extension`, that sets the default fee rebate value used during pool creation.
+
+This value is stored locally in the contract and passed as an argument to the `set-fee-rebate` function of the external `amm-registry-v2-01` contract when a new pool is initialized.
+
+##### Parameters
+
+| Name             | Type   |
+|------------------|--------|
+| `new-fee-rebate` | `uint` |
+
+#### `set-wrapped-token-template`
+
+A public function, governed through the `is-dao-or-extension`, that sets the reference template used to validate wrapper token contracts during permissionless pool creation.
+
+The `wrapped-token-template` is a list of code segments (as ASCII strings) that represent the expected body of a compliant wrapper contract. When a user submits a deployment proof via `create2`, this template is used to reconstruct the expected code and verify that the deployed contract matches it exactly.
+
+##### Parameters
+
+| Name           | Type                                 |
+|----------------|--------------------------------------|
+| `new-template` | `(list 20 (string-ascii 5000))`      |

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -2,16 +2,17 @@
 
 - [Deployed contract](https://explorer.hiro.so/txid/SP1E0XBN9T4B10E9QMR7XMFJPMA19D77WY3KP2QKC.self-listing-helper-v3a?chain=mainnet)
 
-The `self-listing-helper-v3a` contract enables the creation of trading pools on the ALEX DEX through two distinct mechanisms: a permissioned flow and a permissionless flow.
+The `self-listing-helper-v3a` contract enables the creation of trading pools on the ALEX DEX through two distinct mechanisms: a permissioned flow and a permissionless flow. In both cases, pools are formed by pairing a governance-approved anchor token (`token-x`) with a listed token (`token-y`), which is the asset being introduced for trading.
+
+This dual approach gives projects the flexibility to choose between a guided listing process or a fully autonomous, on-chain setup — all while using the same core infrastructure.
 
 ## Permissioned
 
-In the **permissioned flow**, pools can be created with pre-approved tokens by following a guided process through the ALEX UI. Each pool must pair an **anchor token** (`token-x`) with a user-provided token (`token-y`), which is the asset being newly listed (**listed token**). Both anchor and listed tokens must be approved by the ALEX team.
+Pools can be created by following a guided process through the ALEX UI. The user supplies a `token-y` that must be pre-approved by governance before the pool can be initialized.
 
 ## Permissionless
 
-In the **permissionless flow**, users can list a new token (`token-y`) by deploying a wrapper contract that matches an approved template, and without requiring the approval step. The pool is formed against an existing, governance-approved `token-x`. The contract includes a verification system to ensure the integrity of the deployment: it reconstructs and validates the original contract transaction using Merkle proofs and block data, confirming that the wrapper is trustworthy.
-Once verification succeeds, the token is dynamically approved and a pool is created.
+Users can list a new `token-y` without requiring a prior approval step by deploying a wrapper contract that matches a governance-approved template. The contract includes a verification system that reconstructs and validates the original deployment transaction using Merkle proofs and block data. Once verification succeeds, the token is dynamically approved and the pool is created.
 
 ## Additional Capabilities
 
@@ -21,8 +22,6 @@ The contract also supports:
 - On-chain parameter configuration (fees, oracles, thresholds)
 - Governance-controlled token approvals
 - Rebates management for AMM incentives
-
-This dual approach gives projects the flexibility to choose between a guided listing process or a fully autonomous, on-chain setup — all while using the same core infrastructure.
 
 ## Features
 
@@ -293,7 +292,7 @@ This allows the AMM system to recognize and route trades through the correct wra
 
 - `executor-dao`: calls are made to verify whether a certain contract-caller is designated as an extension.
 - `liquidity-locker`: this contract is used to manage post-creation liquidity settings. It allows the contract to lock, burn, or later claim LP tokens based on the pool creator’s configuration.
-- `clarity-stacks`: this contract is used to verify that a token wrapper contract was properly deployed on the Stacks blockchain. It ensures the deployment was mined and included in a valid block.
+- `clarity-stacks`: this contract is used to verify that a wrapper contract was properly deployed on the Stacks blockchain. It checks that the contract was mined and included in a valid block. This system is built on top of Marvin Janssen’s `clarity-stacks` proof framework.
 - `clarity-stacks-helper`: this contract is called to convert a Clarity string into its consensus-encoded buffer format.
 - `amm-vault-v2-01`: this contract is called to verify that `token-y` has reserves before pool creation and to approve it in the permissionless listing flow after successful wrapper verification.
 - `amm-pool-v2-01`: this contract is used to validate pool existence, create new trading pools, and configure pool parameters such as fees, slippage thresholds, oracles, and start block.

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -8,11 +8,11 @@ This dual approach gives projects the flexibility to choose between a guided lis
 
 ## Permissioned
 
-Pools can be created by following a guided process through the ALEX UI. The user supplies a `token-y` that must be pre-approved by governance before the pool can be initialized.
+Pools can be created by following a guided process through the [ALEX Lab UI](https://app.alexlab.co/self-service-listing). The user supplies a `token-y` that must be pre-approved by governance before the pool can be initialized.
 
 ## Permissionless
 
-Users can list a new `token-y` without requiring a prior approval step by deploying a wrapper contract that matches a governance-approved template. The contract includes a verification system that reconstructs and validates the original deployment transaction using Merkle proofs and block data. Once verification succeeds, the token is dynamically approved and the pool is created.
+Users can list a new `token-y` without requiring a prior approval step by deploying a wrapper contract that matches a governance-approved template. The contract includes a verification system, based on the [`clarity-stacks`](https://github.com/MarvinJanssen/clarity-stacks) library, that reconstructs and validates the original deployment transaction using Merkle proofs and block data. Once verification succeeds, the token is dynamically approved and the pool is created.
 
 ## Additional Capabilities
 
@@ -292,7 +292,7 @@ This allows the AMM system to recognize and route trades through the correct wra
 
 - `executor-dao`: calls are made to verify whether a certain contract-caller is designated as an extension.
 - `liquidity-locker`: this contract is used to manage post-creation liquidity settings. It allows the contract to lock, burn, or later claim LP tokens based on the pool creator’s configuration.
-- `clarity-stacks`: this contract is used to verify that a wrapper contract was properly deployed on the Stacks blockchain. It checks that the contract was mined and included in a valid block. This system is built on top of Marvin Janssen’s `clarity-stacks` proof framework.
+- `clarity-stacks`: this contract is used to verify that a wrapper contract was properly deployed on the Stacks blockchain. It checks that the contract was mined and included in a valid block. This system is built on top of Marvin Janssen’s [`clarity-stacks`](https://github.com/MarvinJanssen/clarity-stacks) proof framework.
 - `clarity-stacks-helper`: this contract is called to convert a Clarity string into its consensus-encoded buffer format.
 - `amm-vault-v2-01`: this contract is called to verify that `token-y` has reserves before pool creation and to approve it in the permissionless listing flow after successful wrapper verification.
 - `amm-pool-v2-01`: this contract is used to validate pool existence, create new trading pools, and configure pool parameters such as fees, slippage thresholds, oracles, and start block.

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -1,8 +1,9 @@
 # self-listing-helper-v3a.clar
 
+- Location: `./contracts/extensions/self-listing-helper-v3a.clar`
 - [Deployed contract](https://explorer.hiro.so/txid/SP1E0XBN9T4B10E9QMR7XMFJPMA19D77WY3KP2QKC.self-listing-helper-v3a?chain=mainnet)
 
-The `self-listing-helper-v3a` contract enables the creation of trading pools on the ALEX DEX through two distinct mechanisms: a permissioned flow and a permissionless flow. In both cases, pools are formed by pairing a governance-approved anchor token (`token-x`) with a listed token (`token-y`), which is the asset being introduced for trading.
+The `self-listing-helper-v3a` contract enables the creation of trading pools on the ALEX DEX through two distinct mechanisms: a governance-controlled flow and a permissionless flow. In both cases, pools are formed by pairing a governance-approved anchor token (`token-x`) with a listed token (`token-y`), which is the asset being introduced for trading.
 
 This dual approach gives projects the flexibility to choose between a guided listing process or a fully autonomous, on-chain setup — all while using the same core infrastructure.
 
@@ -12,7 +13,7 @@ Pools can be created by following a guided process through the [ALEX Lab UI](htt
 
 ## Permissionless
 
-Users can list a new `token-y` without requiring a prior approval step by deploying a wrapper contract that matches a governance-approved template. The contract includes a verification system, based on the [`clarity-stacks`](https://github.com/MarvinJanssen/clarity-stacks) library, that reconstructs and validates the original deployment transaction using Merkle proofs and block data. Once verification succeeds, the token is dynamically approved and the pool is created.
+Users can list a new `token-y` without prior approval by deploying a wrapper contract that matches a governance-approved template. The contract includes a verification system, based on the [`clarity-stacks`](https://github.com/MarvinJanssen/clarity-stacks) library, that reconstructs and validates the original deployment transaction using Merkle proofs and block data. Once verification succeeds, the token is dynamically approved and the pool is created.
 
 ## Additional Capabilities
 
@@ -72,7 +73,7 @@ Finally, [`post-check`](#post-check) is executed to create the pool and configur
 
 #### `lock-liquidity`
 
-This function locks a specified amount of LP tokens for a given pool. It is typically used immediately after a pool is created, when the creator chooses to lock the initial liquidity as a trust signal for other users.
+This function locks a specified amount of LP tokens for a given pool. It is typically used immediately after a pool is created, when the creator chooses to lock the initial liquidity to signal trust to other users.
 
 Internally, it calls the `lock-liquidity` function of the `liquidity-locker` contract. That contract:
 
@@ -127,7 +128,7 @@ This standard protocol function checks whether a caller (`tx-sender`) is the DAO
 
 #### `approve-token-x`
 
-A public function, governed through the `is-dao-or-extension`, that sets the approval status and minimum required balance for a token to be used as the anchor token (`token-x`) in pool creation.
+A public function, governed through `is-dao-or-extension`, that sets the approval status and minimum required balance for a token to be used as the anchor token (`token-x`) in pool creation.
 
 This function updates the `approved-token-x` map, enabling the protocol to define which tokens can serve as anchors and to enforce a minimum contribution threshold (`min-x`) for those tokens.
 
@@ -141,7 +142,7 @@ This function updates the `approved-token-x` map, enabling the protocol to defin
 
 #### `set-fee-rebate`
 
-A public function, governed through the `is-dao-or-extension`, that sets the default fee rebate value used during pool creation.
+A public function, governed through `is-dao-or-extension`, that sets the default fee rebate value used during pool creation.
 
 This value is stored locally in the contract and passed as an argument to the `set-fee-rebate` function of the `amm-registry-v2-01` contract when a new pool is initialized.
 
@@ -153,7 +154,7 @@ This value is stored locally in the contract and passed as an argument to the `s
 
 #### `set-wrapped-token-template`
 
-A public function, governed through the `is-dao-or-extension`, that sets the reference template used to validate wrapper token contracts during permissionless pool creation.
+A public function, governed through `is-dao-or-extension`, that sets the reference template used to validate wrapper token contracts during permissionless pool creation.
 
 The `wrapped-token-template` is a list of code segments (as ASCII strings) that represent the expected body of a compliant wrapper contract. When a user submits a deployment proof via `create2`, this template is used to reconstruct the expected code and verify that the deployed contract matches it exactly.
 
@@ -237,9 +238,9 @@ This private function finalizes pool creation by initializing the AMM pool and a
 It performs the following actions:
 
 - Calls the `create-pool` function from the `.amm-pool-v2-01` contract to initialize the pool with the provided liquidity amounts.
-- If the `lock` parameter is set to `LOCK`, it calls `lock-liquidity` from the `liquidity-locker` contract to lock the initial LP tokens.
-- If the `lock` is `BURN`, it calls `burn-liquidity` from the `liquidity-locker` contract instead.
-- Applies pool parameters like fee rates, max ratios, thresholds, oracle settings, and the `start-block` by calling their respective setter functions in the `amm-pool-v2-01` contract.
+- If the `lock` is set to `LOCK`, it calls `lock-liquidity` from the `liquidity-locker` contract to lock the initial LP tokens.
+- If the `lock` is set to `BURN`, it calls `burn-liquidity` from the `liquidity-locker` contract instead.
+- It applies pool parameters like fee rates, max ratios, thresholds, oracle settings, and the `start-block` by calling their respective setter functions in the `amm-pool-v2-01` contract.
 - Finally, it applies the global fee rebate for the pool by calling `set-fee-rebate` from the `amm-registry-v2-01` contract.
 
 This function is used after both `create` and `create2` to complete the pool setup.
@@ -258,7 +259,7 @@ This function is used after both `create` and `create2` to complete the pool set
 | -------- | ----------------------------- |
 | Variable | `list 20 (string-ascii 5000)` |
 
-A list of strings that together define the expected code template for a valid wrapper token contract. Each entry represents a fragment of the full contract body, and the full code is reconstructed by concatenating these parts with the listed token's contract address.
+A list of strings that define the expected code template for a valid wrapper token contract. Each entry represents a fragment of the full contract body, and the full code is reconstructed by concatenating these parts with the listed token's contract address.
 
 This template is used during permissionless pool creation (`create2`) to verify that a wrapper contract deployed by a user matches the expected safe implementation.
 
@@ -312,3 +313,5 @@ This allows the AMM system to recognize and route trades through the correct wra
 | `err-invalid-length-signature`  | `(err u2002)` |
 | `err-invalid-principal-version` | `(err u2003)` |
 | `err-principal-not-contract`    | `(err u2004)` |
+
+<!-- Documentation Contract Template v0.1.1 -->

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -25,7 +25,7 @@ This dual approach gives projects the flexibility to choose between a guided lis
 
 #### `create`
 
-This function initiates the creation of a liquidity pool between two pre-approved tokens. It is used in the **permissioned listing** flow, where the listing token (`token-y`) has already been approved by governance or whitelisted in the system.
+This function initiates the creation of a liquidity pool between two pre-approved tokens. It is used in the permissioned listing flow, where the listing token (`token-y`) has already been approved by governance or whitelisted in the system.
 
 The function first runs validation checks via `pre-check`, which ensures the anchor token (`token-x`) is approved and that the caller provides sufficient liquidity. It also checks that no existing pool with the given token pair and `factor` already exists.
 
@@ -47,7 +47,7 @@ The function emits a print log with the full pool configuration for transparency
 
 #### `create2`
 
-This function allows the creation of a new liquidity pool using a token that has **not been pre-approved** by governance. It is the main entry point for the **permissionless listing** flow.
+This function allows the creation of a new liquidity pool using a token that has not been pre-approved by governance. It is the main entry point for the permissionless listing flow.
 
 Before calling this function, the user must deploy a wrapper contract for the listing token (`token-y`) that matches an approved template. The contract must then be verified on-chain by submitting proof of deployment.
 

--- a/developers/protocol-contracts/self-listing-helper-v3a.clar.md
+++ b/developers/protocol-contracts/self-listing-helper-v3a.clar.md
@@ -153,3 +153,50 @@ The `wrapped-token-template` is a list of code segments (as ASCII strings) that 
 | Name           | Type                                 |
 |----------------|--------------------------------------|
 | `new-template` | `(list 20 (string-ascii 5000))`      |
+
+### Getters
+
+#### `get-approved-token-x-or-default`
+
+##### Parameters
+
+| Name      | Type       |
+|-----------|------------|
+| `token-x` | `principal`|
+
+#### `get-fee-rebate`
+
+#### `get-lock-period`
+
+#### `get-locked-liquidity-or-default`
+
+##### Parameters
+
+| Name     | Type       |
+|----------|------------|
+| `owner`  | `principal`|
+| `pool-id`| `uint`     |
+
+#### `get-locked-liquidity-for-pool-or-default`
+
+##### Parameters
+
+| Name     | Type |
+|----------|------|
+| `pool-id`|`uint`|
+
+#### `get-burnt-liquidity-or-default`
+
+##### Parameters
+
+| Name     | Type |
+|----------|------|
+| `pool-id`|`uint`|
+
+#### `get-wrapped-token-contract-code`
+
+##### Parameters
+
+| Name    | Type       |
+|---------|------------|
+| `token` | `principal`|


### PR DESCRIPTION
Impacts on https://docs.alexgo.io/. This branch is live at a temporary URL [here](https://coinfabrik.gitbook.io/alex-v1-docs/permissionless/developers/protocol-contracts/self-listing-helper-v3a.clar).

The technical documentation for the `self-listing-helper-v3a.clar` contract has been included in the developers section.